### PR TITLE
Add test for injecting failure to k8s job

### DIFF
--- a/resources/templates/k8s/failed-job.yml
+++ b/resources/templates/k8s/failed-job.yml
@@ -1,0 +1,40 @@
+apiVersion: batch/v1
+kind: Job 
+metadata:
+  name: "{{._NAME_}}"
+  namespace: "{{.namespace}}"
+spec:
+  backoffLimit: {{.backoffLimit}}
+  completions: {{.completions}} 
+  parallelism: {{.parallelism}}
+  completionMode: {{.completionMode}}
+  template:
+    metadata:
+      labels:
+        pod-init-container-running-failed.stage.kwok.x-k8s.io: "true"
+      annotations:
+        pod-init-container-running-failed.stage.kwok.x-k8s.io/container-name: "{{.failureContainerName}}"
+        pod-init-container-running-failed.stage.kwok.x-k8s.io/reason: "{{.failureReason}}"
+        pod-init-container-running-failed.stage.kwok.x-k8s.io/message: "{{.failureMessage}}"
+        pod-init-container-running-failed.stage.kwok.x-k8s.io/exit-code: "{{.failureExitCode}}"
+        pod-init-container-running-failed.stage.kwok.x-k8s.io/delay: "{{.failureDelay}}"
+        pod-init-container-running-failed.stage.kwok.x-k8s.io/jitter-delay: "{{.failureJitterDelay}}"
+    spec:
+      schedulerName: default-scheduler
+      initContainers:
+      - name: {{.failureContainerName}}
+        image: {{.initContainerImage}}
+      containers:
+      - name: test
+        image: {{.containerImage}}
+        imagePullPolicy: IfNotPresent
+        resources:
+          limits:
+            cpu: "{{.cpu}}"
+            memory: {{.memory}}
+            nvidia.com/gpu: "{{.gpu}}"
+          requests:
+            cpu: "{{.cpu}}"
+            memory: {{.memory}}
+            nvidia.com/gpu: "{{.gpu}}"
+      restartPolicy: OnFailure

--- a/resources/tests/k8s/test-failed-job.yml
+++ b/resources/tests/k8s/test-failed-job.yml
@@ -1,0 +1,37 @@
+name: test-k8s-job
+description: submit and validate a k8s job
+tasks:
+- id: job
+  type: SubmitObj
+  params:
+    count: 1
+    grv:
+      group: batch
+      version: v1
+      resource: jobs
+    template: "resources/templates/k8s/failed-job.yml"
+    nameformat: "job{{._ENUM_}}"
+    overrides:
+      namespace: default
+      parallelism: 1
+      completions: 1
+      backoffLimit: 0
+      completionMode: NonIndexed
+      image: ubuntu
+      cpu: 100m
+      memory: 512M
+      gpu: 8
+      containerImage: ubuntu
+      initContainerImage: nccl
+      failureContainerName: nccl-test
+      failureReason: nccl-test-failed
+      failureMessage: "nccl test failed"
+      failureExitCode: 1
+      failureDelay: 1000
+      failureJitterDelay: 5000
+- id: status
+  type: CheckPod
+  params:
+    refTaskId: job 
+    status: Failed
+    timeout: 10s


### PR DESCRIPTION
This PR adds a test template and file showing injecting an error to a k8s job's initContainer to simulate preflight check failures in running a job.

Test and validation:

```
 bin/knavigator --tasks resources/tests/k8s/test-failed-job.yml
I0508 10:36:49.107691   22759 k8s_config.go:38] "Using external kubeconfig"
I0508 10:36:49.113396   22759 main.go:74] "Starting test" name="test-k8s-job"
I0508 10:36:49.113418   22759 engine.go:99] "Creating task" name="SubmitObj" id="job"
I0508 10:36:49.114101   22759 engine.go:193] "Starting task" id="SubmitObj/job"
I0508 10:36:49.153671   22759 engine.go:199] "Task completed" id="SubmitObj/job" duration="39.553041ms"
I0508 10:36:49.153688   22759 engine.go:99] "Creating task" name="CheckPod" id="status"
I0508 10:36:49.153781   22759 engine.go:193] "Starting task" id="CheckPod/status"
I0508 10:36:49.153789   22759 engine.go:199] "Task completed" id="CheckPod/status" duration="750ns"

$ kubectl get pods
NAME         READY   STATUS                  RESTARTS   AGE
job1-s4hc5   0/1     Init:nccl-test-failed   0          2s

$ kubectl get jobs
NAME   STATUS   COMPLETIONS   DURATION   AGE
job1   Failed   0/1           6s         6s
```