### PR TITLE
Add git workflow for golang linters and unittests

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,0 +1,68 @@
+# This workflow will build a golang project
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-go
+
+name: Go
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+    branches:
+      - main
+  push:
+    branches:
+      - main
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Go
+      uses: actions/setup-go@v4
+      with:
+        go-version: '1.20'
+
+    - name: Lint
+      uses: golangci/golangci-lint-action@v5
+      with:
+        version: 'v1.58.0'
+        args: -v --timeout 5m
+        skip-cache: true
+
+    - name: vet
+      run:
+        make vet
+
+    - name: fmt
+      run:
+        test -z "$(go fmt ./...)"
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Go
+      uses: actions/setup-go@v4
+      with:
+        go-version: '1.20'
+
+    - name: Test
+      run: go test -v ./...
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Go
+      uses: actions/setup-go@v4
+      with:
+        go-version: '1.20'
+
+    - name: Build
+      run: make build

--- a/pkg/engine/check_object_task.go
+++ b/pkg/engine/check_object_task.go
@@ -89,7 +89,7 @@ func (task *CheckObjTask) Exec(ctx context.Context) error {
 	done := make(chan struct{})
 	defer close(done)
 
-	informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+	_, err = informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			resource := obj.(*unstructured.Unstructured)
 			task.log.V(4).Info("Informer added", "resource", info.GVR.Resource, "name", resource.GetName())
@@ -101,6 +101,9 @@ func (task *CheckObjTask) Exec(ctx context.Context) error {
 			task.checkStateAsync(ctx, resource.GetName(), info, nameMap, done)
 		},
 	})
+	if err != nil {
+		return err
+	}
 
 	stopCh := make(chan struct{})
 	go informer.Run(stopCh)

--- a/pkg/engine/submit_object_task.go
+++ b/pkg/engine/submit_object_task.go
@@ -207,10 +207,8 @@ func (task *SubmitObjTask) Exec(ctx context.Context) error {
 		}
 	}
 
-	task.setter.SetObjInfo(task.taskID,
+	return task.setter.SetObjInfo(task.taskID,
 		NewObjInfo([]string{task.obj[0].Metadata.Name}, task.obj[0].Metadata.Namespace, gvr, task.Pods.Names()...))
-
-	return nil
 }
 
 func (obj *GenericObject) UnmarshalYAML(unmarshal func(interface{}) error) error {


### PR DESCRIPTION
* This workflow will be triggered on every push event on the main and when creating or updating new PRs.

* `go vet` might be redundant with golangci-lint as well. But I included it as a part of workflow as Makefile has a separate target for it

* We may also need to introduce golangci config as well.