### PR TITLE
Add verify scripts for various checks

### DIFF
--- a/.yamlfmt.yaml
+++ b/.yamlfmt.yaml
@@ -1,0 +1,4 @@
+formatter:
+  type: basic
+  indentless_arrays: true
+  retain_line_breaks_single: true

--- a/.yamllint.conf
+++ b/.yamllint.conf
@@ -1,0 +1,14 @@
+# configuration file rules
+# https://yamllint.readthedocs.io/en/stable/rules.html
+
+extends: default
+
+ignore-from-file: .gitignore
+
+rules:
+  indentation: disable
+  document-start: disable
+  comments: disable
+  line-length: disable
+  truthy:
+    check-keys: false

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,16 @@ IMAGE_REPO ?=docker.io/nvidia/knavigator
 GIT_REF =$(shell git rev-parse --abbrev-ref HEAD)
 IMAGE_TAG ?=$(GIT_REF)
 
+## verify: Verify code
+.PHONY: verify
+verify:
+	@./hack/verify-all.sh
+
+## update: Update all the generated
+.PHONY: update
+update:
+	@./hack/update-all.sh
+
 .PHONY: build
 build:
 	@for target in $(TARGETS); do        \

--- a/hack/spelling.txt
+++ b/hack/spelling.txt
@@ -1,0 +1,1 @@
+importas

--- a/hack/update-all.sh
+++ b/hack/update-all.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Copyright 2023 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+DIR="$(dirname "${BASH_SOURCE[0]}")"
+
+ROOT_DIR="$(realpath "${DIR}/..")"
+
+failed=()
+
+if [[ "${UPDATE_GO_FORMAT:-true}" == "true" ]]; then
+  echo "[*] Update go format..."
+  "${ROOT_DIR}"/hack/update-go-format.sh || failed+=(go-format)
+fi
+
+if [[ "${UPDATE_GO_MOD:-true}" == "true" ]]; then
+  echo "[*] Update go mod..."
+  "${ROOT_DIR}"/hack/update-go-mod.sh || failed+=(go-mod)
+fi
+
+if [[ "${UPDATE_GO_LINT:-true}" == "true" ]]; then
+  echo "[*] Update go lint..."
+  "${ROOT_DIR}"/hack/update-go-lint.sh || failed+=(go-lint)
+fi
+
+if [[ "${UPDATE_ENDS_NEWLINE:-true}" == "true" ]]; then
+  echo "[*] Update ends newline..."
+  "${ROOT_DIR}"/hack/update-ends-newline.sh || failed+=(ends-newline)
+fi
+
+if [[ "${UPDATE_SHELL_FORMAT:-true}" == "true" ]]; then
+  echo "[*] Update shell format..."
+  "${ROOT_DIR}"/hack/update-shell-format.sh || failed+=(shell-format)
+fi
+
+if [[ "${UPDATE_YAML_FORMAT:-true}" == "true" ]]; then
+  echo "[*] Update yaml format..."
+  "${ROOT_DIR}"/hack/update-yaml-format.sh || failed+=(yaml-format)
+fi
+
+if [[ "${UPDATE_SPELLING:-true}" == "true" ]]; then
+  echo "[*] Update spelling..."
+  "${ROOT_DIR}"/hack/update-spelling.sh || failed+=(spelling)
+fi
+
+if [[ "${#failed[@]}" != 0 ]]; then
+  echo "Update failed for: ${failed[*]}"
+  exit 1
+fi

--- a/hack/update-ends-newline.sh
+++ b/hack/update-ends-newline.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Copyright 2023 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+DIR="$(dirname "${BASH_SOURCE[0]}")"
+
+ROOT_DIR="$(realpath "${DIR}/..")"
+
+function update_ends_newline() {
+  find . \( \
+    -iname "*.md" \
+    -o -iname "*.sh" \
+    -o -iname "*.go" \
+    -o -iname "*.tpl" \
+    -o -iname "*.yaml" \
+    -o -iname "*.yml" \
+    \) \
+    -not \( \
+    -path ./.git/\* \
+    -o -path ./vendor/\* \
+    -o -path ./demo/node_modules/\* \
+    -o -path ./site/themes/\* \
+    \) \
+    -exec sh -c '[ -n "$(tail -c 1 $1)" ] && echo >> $1' sh {} \;
+}
+
+cd "${ROOT_DIR}" && update_ends_newline

--- a/hack/update-go-format.sh
+++ b/hack/update-go-format.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Copyright 2023 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+DIR="$(dirname "${BASH_SOURCE[0]}")"
+
+ROOT_DIR="$(realpath "${DIR}/..")"
+
+function format() {
+  echo "Update go format"
+  mapfile -t findfiles < <(find . \( \
+    -iname "*.go" \
+    \) \
+    -not \( \
+    -path ./vendor/\* \
+    -o -path ./demo/node_modules/\* \
+    -o -path ./site/themes/\* \
+    \))
+  gofmt -s -w "${findfiles[@]}"
+}
+
+cd "${ROOT_DIR}" && format

--- a/hack/update-go-lint.sh
+++ b/hack/update-go-lint.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Copyright 2023 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+DIR="$(dirname "${BASH_SOURCE[0]}")"
+
+ROOT_DIR="$(realpath "${DIR}/..")"
+
+COMMAND=(go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.55.2)
+
+cd "${ROOT_DIR}" && "${COMMAND[@]}" run -c "${ROOT_DIR}/.golangci.yml" --fix

--- a/hack/update-go-mod.sh
+++ b/hack/update-go-mod.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Copyright 2023 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+DIR="$(dirname "${BASH_SOURCE[0]}")"
+
+ROOT_DIR="$(realpath "${DIR}/..")"
+
+cd "${ROOT_DIR}" && go mod tidy

--- a/hack/update-shell-format.sh
+++ b/hack/update-shell-format.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Copyright 2023 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+DIR="$(dirname "${BASH_SOURCE[0]}")"
+
+ROOT_DIR="$(realpath "${DIR}/..")"
+
+function format() {
+  echo "Update shell format"
+  mapfile -t findfiles < <(find . \( \
+    -iname "*.sh" \
+    \) \
+    -not \( \
+    -path ./vendor/\* \
+    -o -path ./demo/node_modules/\* \
+    -o -path ./site/themes/\* \
+    \))
+  go run mvdan.cc/sh/v3/cmd/shfmt@v3.7.0 -w -i=2 "${findfiles[@]}"
+}
+
+cd "${ROOT_DIR}" && format

--- a/hack/update-spelling.sh
+++ b/hack/update-spelling.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Copyright 2023 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+DIR="$(dirname "${BASH_SOURCE[0]}")"
+
+ROOT_DIR="$(realpath "${DIR}/..")"
+
+allowed_spelling_words="${ROOT_DIR}/hack/spelling.txt"
+
+function update() {
+  local ignore
+  ignore="$(tr <"${allowed_spelling_words}" '\n' ',')"
+  mapfile -t files < <(find . \( \
+    -iname "*.md" \
+    -o -iname "*.sh" \
+    -o -iname "*.go" \
+    -o -iname "*.tpl" \
+    -o -iname "*.yaml" \
+    -o -iname "*.yml" \
+    \) \
+    -not \( \
+    -path ./.git/\* \
+    -o -path ./vendor/\* \
+    -o -path ./demo/node_modules/\* \
+    -o -path ./site/themes/\* \
+    \))
+  go run github.com/client9/misspell/cmd/misspell@v0.3.4 \
+    -locale US -w -i "${ignore}" "${files[@]}"
+}
+
+cd "${ROOT_DIR}" && update

--- a/hack/update-yaml-format.sh
+++ b/hack/update-yaml-format.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Copyright 2024 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+DIR="$(dirname "${BASH_SOURCE[0]}")"
+
+ROOT_DIR="$(realpath "${DIR}/..")"
+
+function format() {
+  echo "Update yaml format"
+  mapfile -t findfiles < <(find . \( \
+    -iname "*.yaml" \
+    -o -iname "*.yml" \
+    \) \
+    -not \( \
+    -path ./vendor/\* \
+    -o -path ./demo/node_modules/\* \
+    -o -path ./site/themes/\* \
+    -o -path ./kustomize/crd/bases/\* \
+    -o -path ./kustomize/rbac/\* \
+    \))
+  go run github.com/google/yamlfmt/cmd/yamlfmt@v0.11.0 -conf .yamlfmt.yaml "${findfiles[@]}"
+}
+
+cd "${ROOT_DIR}" && format

--- a/hack/verify-all.sh
+++ b/hack/verify-all.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# Copyright 2022 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+DIR="$(dirname "${BASH_SOURCE[0]}")"
+
+ROOT_DIR="$(realpath "${DIR}/..")"
+
+failed=()
+
+if [[ "${VERIFY_ENDS_NEWLINE:-true}" == "true" ]]; then
+  echo "[*] Verifying ends newline..."
+  "${ROOT_DIR}"/hack/verify-ends-newline.sh || failed+=(ends-newline)
+fi
+
+if [[ "${VERIFY_GO_MOD:-true}" == "true" ]]; then
+  echo "[*] Verifying go mod..."
+  "${ROOT_DIR}"/hack/verify-go-mod.sh || failed+=(go-mod)
+fi
+
+if [[ "${VERIFY_GO_FORMAT:-true}" == "true" ]]; then
+  echo "[*] Verifying go format..."
+  "${ROOT_DIR}"/hack/verify-go-format.sh || failed+=(go-format)
+fi
+
+if [[ "${VERIFY_GO_LINT:-true}" == "true" ]]; then
+  echo "[*] Verifying go lint..."
+  "${ROOT_DIR}"/hack/verify-go-lint.sh || failed+=(go-lint)
+fi
+
+if [[ "${VERIFY_YAMLLINT:-true}" == "true" ]]; then
+  echo "[*] Verifying YAML lint..."
+  "${ROOT_DIR}"/hack/verify-yamllint.sh || failed+=(yamllint)
+fi
+
+if [[ "${VERIFY_SHELLCHECK:-true}" == "true" ]]; then
+  echo "[*] Verifying shell check..."
+  "${ROOT_DIR}"/hack/verify-shellcheck.sh || failed+=(shellcheck)
+fi
+
+if [[ "${VERIFY_SHELL_FORMAT:-true}" == "true" ]]; then
+  echo "[*] Verifying shell format..."
+  "${ROOT_DIR}"/hack/verify-shell-format.sh || failed+=(shell-format)
+fi
+
+if [[ "${VERIFY_YAML_FORMAT:-true}" == "true" ]]; then
+  echo "[*] Verifying yaml format..."
+  "${ROOT_DIR}"/hack/verify-yaml-format.sh || failed+=(yaml-format)
+fi
+
+if [[ "${VERIFY_SPELLING:-true}" == "true" ]]; then
+  echo "[*] Verifying spelling..."
+  "${ROOT_DIR}"/hack/verify-spelling.sh || failed+=(spelling)
+fi
+
+# exit based on verify scripts
+if [[ "${#failed[@]}" != 0 ]]; then
+  echo "Verify failed for: ${failed[*]}"
+  exit 1
+fi

--- a/hack/verify-ends-newline.sh
+++ b/hack/verify-ends-newline.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Copyright 2022 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+DIR="$(dirname "${BASH_SOURCE[0]}")"
+
+ROOT_DIR="$(realpath "${DIR}/..")"
+
+function check_ends() {
+  find . \( \
+    -iname "*.md" \
+    -o -iname "*.sh" \
+    -o -iname "*.go" \
+    -o -iname "*.tpl" \
+    -o -iname "*.yaml" \
+    -o -iname "*.yml" \
+    \) \
+    -not \( \
+    -path ./.git/\* \
+    -o -path ./vendor/\* \
+    -o -path ./demo/node_modules/\* \
+    -o -path ./site/themes/\* \
+    \) \
+    -exec sh -c '[ -n "$(tail -c 1 "$1")" ] && echo "$1"' sh {} \;
+}
+
+function check() {
+  out="$(check_ends)"
+  if [[ "${out}" != "" ]]; then
+    echo "Add a new line in ends for below files"
+    echo "${out}"
+    return 1
+  fi
+}
+
+cd "${ROOT_DIR}" && check

--- a/hack/verify-go-format.sh
+++ b/hack/verify-go-format.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Copyright 2022 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+DIR="$(dirname "${BASH_SOURCE[0]}")"
+
+ROOT_DIR="$(realpath "${DIR}/..")"
+
+function check() {
+  echo "Verify go format"
+  mapfile -t findfiles < <(find . \( \
+    -iname "*.go" \
+    \) \
+    -not \( \
+    -path ./vendor/\* \
+    -o -path ./demo/node_modules/\* \
+    -o -path ./site/themes/\* \
+    \))
+  out="$(gofmt -s -w "${findfiles[@]}")"
+
+  if [[ -n "${out}" ]]; then
+    echo "${out}"
+    return 1
+  fi
+}
+
+cd "${ROOT_DIR}" && check

--- a/hack/verify-go-lint.sh
+++ b/hack/verify-go-lint.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Copyright 2023 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+DIR="$(dirname "${BASH_SOURCE[0]}")"
+
+ROOT_DIR="$(realpath "${DIR}/..")"
+
+COMMAND=(go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.55.2)
+
+cd "${ROOT_DIR}" && "${COMMAND[@]}" run -c "${ROOT_DIR}/.golangci.yml"

--- a/hack/verify-go-mod.sh
+++ b/hack/verify-go-mod.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Copyright 2022 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+DIR="$(dirname "${BASH_SOURCE[0]}")"
+
+ROOT_DIR="$(realpath "${DIR}/..")"
+
+function check() {
+  echo "Verify go.mod & go.sum"
+  go mod tidy
+  git --no-pager diff --exit-code go.mod go.sum
+}
+
+cd "${ROOT_DIR}" && check

--- a/hack/verify-shell-format.sh
+++ b/hack/verify-shell-format.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Copyright 2023 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+DIR="$(dirname "${BASH_SOURCE[0]}")"
+
+ROOT_DIR="$(realpath "${DIR}/..")"
+
+function check() {
+  echo "Verify shell format"
+  "${ROOT_DIR}"/hack/update-shell-format.sh
+  git --no-pager diff --exit-code
+}
+
+cd "${ROOT_DIR}" && check

--- a/hack/verify-shellcheck.sh
+++ b/hack/verify-shellcheck.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# Copyright 2023 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+DIR="$(dirname "${BASH_SOURCE[0]}")"
+
+ROOT_DIR="$(realpath "${DIR}/..")"
+
+SHELLCHECK_VERSION="0.9.0"
+
+# disabled lints
+disabled=(
+  # this lint disallows non-constant source, which we use extensively without
+  # any known bugs
+  1090
+  # this lint warns when shellcheck cannot find a sourced file
+  # this wouldn't be a bad idea to warn on, but it fails on lots of path
+  # dependent sourcing, so just disable enforcing it
+  1091
+  # this lint prefers command -v to which, they are not the same
+  2230
+)
+# comma separate for passing to shellcheck
+join_by() {
+  local IFS="$1"
+  shift
+  echo "$*"
+}
+SHELLCHECK_DISABLED="$(join_by , "${disabled[@]}")"
+readonly SHELLCHECK_DISABLED
+
+mapfile -t findfiles < <(find . \( \
+  -iname "*.sh" \
+  \) \
+  -not \( \
+  -path ./vendor/\* \
+  -o -path ./demo/node_modules/\* \
+  -o -path ./site/themes/\* \
+  \))
+
+SHELLCHECK_OPTIONS=(
+  "--external-sources"
+  "--exclude=${SHELLCHECK_DISABLED}"
+  "--color=always"
+)
+
+HAVE_SHELLCHECK=false
+if command -v shellcheck; then
+  detected_version="$(shellcheck --version | grep 'version: .*')"
+  if [[ "${detected_version}" == "version: ${SHELLCHECK_VERSION}" ]]; then
+    HAVE_SHELLCHECK=true
+  fi
+fi
+
+COMMAND=()
+if ${HAVE_SHELLCHECK}; then
+  COMMAND=(shellcheck)
+elif command -v "${ROOT_DIR}/bin/shellcheck"; then
+  COMMAND=("${ROOT_DIR}/bin/shellcheck")
+elif [[ "$(uname -s)" == "Linux" ]] && [[ "$(uname -m)" == "x86_64" ]]; then
+  wget -qO- "https://github.com/koalaman/shellcheck/releases/download/v${SHELLCHECK_VERSION?}/shellcheck-v${SHELLCHECK_VERSION?}.linux.x86_64.tar.xz" | tar -xJv
+  mkdir -p "${ROOT_DIR}"/bin
+  mv "shellcheck-v${SHELLCHECK_VERSION}/shellcheck" "${ROOT_DIR}/bin/"
+  COMMAND=("${ROOT_DIR}/bin/shellcheck")
+elif command -v docker; then
+  COMMAND=(
+    docker run
+    --rm
+    -v "${ROOT_DIR}:${ROOT_DIR}"
+    -w "${ROOT_DIR}"
+    docker.io/koalaman/shellcheck-alpine:v0.9.0@sha256:e19ed93c22423970d56568e171b4512c9244fc75dd9114045016b4a0073ac4b7
+    shellcheck
+  )
+else
+  echo "WARNING: shellcheck or docker not installed" >&2
+  exit 1
+fi
+
+cd "${ROOT_DIR}" && "${COMMAND[@]}" "${SHELLCHECK_OPTIONS[@]}" "${findfiles[@]}"

--- a/hack/verify-spelling.sh
+++ b/hack/verify-spelling.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Copyright 2023 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+DIR="$(dirname "${BASH_SOURCE[0]}")"
+
+ROOT_DIR="$(realpath "${DIR}/..")"
+
+function check() {
+  echo "Verify spelling"
+  "${ROOT_DIR}"/hack/update-spelling.sh
+  git --no-pager diff --exit-code
+}
+
+cd "${ROOT_DIR}" && check

--- a/hack/verify-yaml-format.sh
+++ b/hack/verify-yaml-format.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Copyright 2024 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+DIR="$(dirname "${BASH_SOURCE[0]}")"
+
+ROOT_DIR="$(realpath "${DIR}/..")"
+
+function check() {
+  echo "Verify yaml format"
+  "${ROOT_DIR}"/hack/update-yaml-format.sh
+  git --no-pager diff --exit-code
+}
+
+cd "${ROOT_DIR}" && check

--- a/hack/verify-yamllint.sh
+++ b/hack/verify-yamllint.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Copyright 2023 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+DIR="$(dirname "${BASH_SOURCE[0]}")"
+
+ROOT_DIR="$(realpath "${DIR}/..")"
+
+COMMAND=()
+if command -v yamllint; then
+  COMMAND=(yamllint)
+elif command -v "${ROOT_DIR}/venv/bin/yamllint"; then
+  COMMAND=("${ROOT_DIR}/venv/bin/yamllint")
+elif command -v python3; then
+  python3 -m venv "${ROOT_DIR}/venv"
+  source "${ROOT_DIR}/venv/bin/activate"
+  pip install yamllint
+  COMMAND=("${ROOT_DIR}/venv/bin/yamllint")
+elif command -v docker; then
+  COMMAND=(
+    docker run
+    --rm -i
+    -v "${ROOT_DIR}:/workdir"
+    -w "/workdir"
+    --security-opt="label=disable"
+    "docker.io/cytopia/yamllint:1.26@sha256:1bf8270a671a2e5f2fea8ac2e80164d627e0c5fa083759862bbde80628f942b2"
+  )
+else
+  echo "WARNING: yamllint, python3 or docker not installed" >&2
+  exit 1
+fi
+
+function check() {
+  echo "Verify go format"
+  mapfile -t findfiles < <(find . \( \
+    -iname "*.yaml" \
+    -o -iname "*.yml" \
+    \) \
+    -not \( \
+    -path ./vendor/\* \
+    -o -path ./demo/node_modules/\* \
+    -o -path ./site/themes/\* \
+    \))
+
+  "${COMMAND[@]}" -s -c .yamllint.conf "${findfiles[@]}"
+}
+
+cd "${ROOT_DIR}" && check


### PR DESCRIPTION
Add verification and check scripts: gofmt, golint, spelling check, yaml format, ...
`hack/verifiy-all`  or `make verify` will perform all checks.
`hack/update-all` or `make update` will correct all the issues.
