### PR TITLE
Fix issues reported by verification scripts

### DIFF
--- a/pkg/utils/k8s_config.go
+++ b/pkg/utils/k8s_config.go
@@ -45,7 +45,7 @@ func GetK8sConfig(log logr.Logger, kubeConfigPath, kubectx string) (*rest.Config
 	if err != nil {
 		return nil, err
 	}
-	//update cert file location if needed
+	// update cert file location if needed
 	for _, info := range config.AuthInfos {
 		if len(info.LocationOfOrigin) != 0 {
 			dir := filepath.Dir(info.LocationOfOrigin)


### PR DESCRIPTION
This PR addresses the following issues reported by verification scripts (spelling, `gofmt`, and `golint`) in the current code and documentation:
1. Go import package order, e.g.,  `knavigator` packages should be at the end.
2. Typos.
