### PR TITLE
Fix  two errors reported by golangci-lint

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -55,6 +55,7 @@ func New(data []byte) (*TaskConfig, error) {
 
 // NewFromFile populates test config from YAML file
 func NewFromFile(path string) (*TaskConfig, error) {
+	path = filepath.Clean(path)
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err

--- a/pkg/utils/k8s_config_test.go
+++ b/pkg/utils/k8s_config_test.go
@@ -110,11 +110,11 @@ func TestGetK8sConfig(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			os.Unsetenv("KUBECONFIG")
+			_ = os.Unsetenv("KUBECONFIG")
 			if len(tc.envCfg) != 0 {
 				f, err := os.CreateTemp("", "test")
 				require.NoError(t, err)
-				defer os.Remove(f.Name())
+				defer func() { _ = os.Remove(f.Name()) }()
 
 				_, err = f.Write([]byte(tc.envCfg))
 				require.NoError(t, err)
@@ -127,7 +127,7 @@ func TestGetK8sConfig(t *testing.T) {
 			if len(tc.kubeCfg) != 0 {
 				f, err := os.CreateTemp("", "test")
 				require.NoError(t, err)
-				defer os.Remove(f.Name())
+				defer func() { _ = os.Remove(f.Name()) }()
 
 				_, err = f.Write([]byte(tc.kubeCfg))
 				require.NoError(t, err)


### PR DESCRIPTION
This PR fixes the following two errors reported by `golang-lint`.
```
$ golangci-lint run ./...
WARN [lintersdb] The linter named "megacheck" is deprecated. It has been split into: gosimple, staticcheck, unused.
pkg/utils/k8s_config_test.go:113:15: Error return value of `os.Unsetenv` is not checked (errcheck)
			os.Unsetenv("KUBECONFIG")
			           ^
pkg/utils/k8s_config_test.go:117:20: Error return value of `os.Remove` is not checked (errcheck)
				defer os.Remove(f.Name())
				               ^
pkg/utils/k8s_config_test.go:130:20: Error return value of `os.Remove` is not checked (errcheck)
				defer os.Remove(f.Name())
				               ^
pkg/config/config.go:58:15: G304: Potential file inclusion via variable (gosec)
	data, err := os.ReadFile(path)
	             ^
```