### PR TITLE
implemented registration of CRDs

### DIFF
--- a/pkg/engine/check_object_task.go
+++ b/pkg/engine/check_object_task.go
@@ -37,7 +37,7 @@ type CheckObjTask struct {
 }
 
 // newCheckObjTask initializes and returns CheckObjTask
-func newCheckObjTask(log logr.Logger, client *dynamic.DynamicClient, getter ObjGetter, cfg *config.Task) (*CheckObjTask, error) {
+func newCheckObjTask(log logr.Logger, client *dynamic.DynamicClient, accessor ObjInfoAccessor, cfg *config.Task) (*CheckObjTask, error) {
 	if client == nil {
 		return nil, fmt.Errorf("%s/%s: DynamicClient is not set", cfg.Type, cfg.ID)
 	}
@@ -49,8 +49,8 @@ func newCheckObjTask(log logr.Logger, client *dynamic.DynamicClient, getter ObjG
 				taskType: cfg.Type,
 				taskID:   cfg.ID,
 			},
-			client: client,
-			getter: getter,
+			client:   client,
+			accessor: accessor,
 		},
 	}
 
@@ -63,7 +63,7 @@ func newCheckObjTask(log logr.Logger, client *dynamic.DynamicClient, getter ObjG
 
 // Exec implements Runnable interface
 func (task *CheckObjTask) Exec(ctx context.Context) error {
-	info, err := task.getter.GetObjInfo(task.RefTaskID)
+	info, err := task.accessor.GetObjInfo(task.RefTaskID)
 	if err != nil {
 		return err
 	}

--- a/pkg/engine/check_object_task_test.go
+++ b/pkg/engine/check_object_task_test.go
@@ -90,7 +90,7 @@ func TestNewCheckObjTask(t *testing.T) {
 			eng, err := New(testLogger, nil, tc.simClients)
 			require.NoError(t, err)
 			if len(tc.refTaskId) != 0 {
-				eng.objMap[tc.refTaskId] = nil
+				eng.objInfoMap[tc.refTaskId] = nil
 			}
 
 			task, err := eng.GetTask(&config.Task{
@@ -102,7 +102,7 @@ func TestNewCheckObjTask(t *testing.T) {
 				require.EqualError(t, err, tc.err)
 				require.Nil(t, tc.task)
 			} else {
-				tc.task.getter = eng
+				tc.task.accessor = eng
 				require.NoError(t, err)
 				require.NotNil(t, tc.task)
 				require.Equal(t, tc.task, task)

--- a/pkg/engine/check_pod_task.go
+++ b/pkg/engine/check_pod_task.go
@@ -19,6 +19,7 @@ package engine
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -41,8 +42,8 @@ type CheckPodTask struct {
 	BaseTask
 	checkPodTaskParams
 
-	client *kubernetes.Clientset
-	getter ObjGetter
+	client   *kubernetes.Clientset
+	accessor ObjInfoAccessor
 }
 
 type checkPodTaskParams struct {
@@ -53,7 +54,7 @@ type checkPodTaskParams struct {
 }
 
 // newCheckPodTask initializes and returns CheckPodTask
-func newCheckPodTask(log logr.Logger, client *kubernetes.Clientset, getter ObjGetter, cfg *config.Task) (*CheckPodTask, error) {
+func newCheckPodTask(log logr.Logger, client *kubernetes.Clientset, accessor ObjInfoAccessor, cfg *config.Task) (*CheckPodTask, error) {
 	if client == nil {
 		return nil, fmt.Errorf("%s/%s: Kubernetes client is not set", cfg.Type, cfg.ID)
 	}
@@ -64,8 +65,8 @@ func newCheckPodTask(log logr.Logger, client *kubernetes.Clientset, getter ObjGe
 			taskType: cfg.Type,
 			taskID:   cfg.ID,
 		},
-		client: client,
-		getter: getter,
+		client:   client,
+		accessor: accessor,
 	}
 
 	if err := task.validate(cfg.Params); err != nil {
@@ -98,13 +99,13 @@ func (task *CheckPodTask) validate(params map[string]interface{}) error {
 
 // Exec implements Runnable interface
 func (task *CheckPodTask) Exec(ctx context.Context) error {
-	info, err := task.getter.GetObjInfo(task.RefTaskID)
+	info, err := task.accessor.GetObjInfo(task.RefTaskID)
 	if err != nil {
 		return err
 	}
 
-	if len(info.Pods) == 0 {
-		return nil
+	if len(info.PodRegexp) == 0 {
+		return fmt.Errorf("%s: no pods to check", task.ID())
 	}
 
 	if task.Timeout == 0 {
@@ -114,20 +115,38 @@ func (task *CheckPodTask) Exec(ctx context.Context) error {
 }
 
 func (task *CheckPodTask) checkPods(ctx context.Context, info *ObjInfo) error {
-	for _, name := range info.Pods {
-		pod, err := task.client.CoreV1().Pods(info.Namespace).Get(ctx, name, metav1.GetOptions{})
-		if err != nil {
-			return fmt.Errorf("%s: failed to get pod '%s': %v", task.ID(), name, err)
-		}
+	list, err := task.client.CoreV1().Pods(info.Namespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return fmt.Errorf("%s: failed to list pods: %v", task.ID(), err)
+	}
 
-		status := string(pod.Status.Phase)
-		if status != task.Status {
-			return fmt.Errorf("%s: pod %s, status %s, expected %s", task.ID(), name, status, task.Status)
-		}
+	re, err := utils.Exp2Regexp(info.PodRegexp)
+	if err != nil {
+		return fmt.Errorf("%s: %v", task.ID(), err)
+	}
 
-		if err := task.verifyLabels(ctx, pod); err != nil {
-			return err
+	var count int
+	for i := range list.Items {
+		pod := &list.Items[i]
+		for _, r := range re {
+			if r.MatchString(pod.Name) {
+				task.log.V(4).Info("Matched pod", "name", pod.Name)
+				count++
+
+				status := string(pod.Status.Phase)
+				if status != task.Status {
+					return fmt.Errorf("%s: pod %s, status %s, expected %s", task.ID(), pod.Name, status, task.Status)
+				}
+
+				if err := task.verifyLabels(ctx, pod); err != nil {
+					return err
+				}
+			}
 		}
+	}
+
+	if count != info.PodCount {
+		return fmt.Errorf("%s: verified %d pods, expected %d", task.ID(), count, info.PodCount)
 	}
 
 	return nil
@@ -136,15 +155,17 @@ func (task *CheckPodTask) checkPods(ctx context.Context, info *ObjInfo) error {
 // watchPods watches statuses of given pods and compares them with the expected status.
 // The function runs until all statuses are equal to the expected one, or until the timeout, whichever comes first.
 func (task *CheckPodTask) watchPods(ctx context.Context, info *ObjInfo) error {
-	task.log.Info("Create pod informer", "#pods", len(info.Pods), "timeout", task.Timeout.String())
+	task.log.Info("Create pod informer", "#pod", info.PodCount, "timeout", task.Timeout.String())
+
+	re, err := utils.Exp2Regexp(info.PodRegexp)
+	if err != nil {
+		return fmt.Errorf("%s: %v", task.ID(), err)
+	}
 
 	ctx, cancel := context.WithTimeout(ctx, task.Timeout)
 	defer cancel()
 
 	podMap := utils.NewSyncMap()
-	for _, pod := range info.Pods {
-		podMap.Set(pod, true)
-	}
 
 	errs := make(chan error)
 
@@ -153,12 +174,12 @@ func (task *CheckPodTask) watchPods(ctx context.Context, info *ObjInfo) error {
 
 	informer := factory.Core().V1().Pods().Informer()
 
-	_, err := informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+	_, err = informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
-			task.verifyPod(ctx, podMap, obj, errs)
+			task.verifyPod(ctx, re, podMap, info.PodCount, obj, errs)
 		},
 		UpdateFunc: func(_, obj interface{}) {
-			task.verifyPod(ctx, podMap, obj, errs)
+			task.verifyPod(ctx, re, podMap, info.PodCount, obj, errs)
 		},
 	})
 	if err != nil {
@@ -173,10 +194,10 @@ func (task *CheckPodTask) watchPods(ctx context.Context, info *ObjInfo) error {
 			return
 		}
 		for i := range list.Items {
-			if podMap.Size() == 0 {
+			if podMap.Size() == info.PodCount {
 				break
 			}
-			task.verifyPod(ctx, podMap, &list.Items[i], errs)
+			task.verifyPod(ctx, re, podMap, info.PodCount, &list.Items[i], errs)
 		}
 	}()
 
@@ -209,24 +230,33 @@ func (task *CheckPodTask) verifyLabels(ctx context.Context, pod *v1.Pod) error {
 	return nil
 }
 
-func (task *CheckPodTask) verifyPod(ctx context.Context, podMap *utils.SyncMap, obj interface{}, errs chan error) {
+func (task *CheckPodTask) verifyPod(ctx context.Context, re []*regexp.Regexp, podMap *utils.SyncMap, count int, obj interface{}, errs chan error) {
 	pod, ok := obj.(*v1.Pod)
 	if !ok {
 		errs <- fmt.Errorf("%s: unexpected object type %T, expected *v1.Pod", task.ID(), obj)
 		return
 	}
 
-	if _, ok := podMap.Get(pod.Name); ok {
-		status := string(pod.Status.Phase)
-		task.log.V(4).Info("Informer event", "pod", pod.Name, "status", status)
-		if err := task.verifyLabels(ctx, pod); err != nil {
-			errs <- err
-			return
-		}
-		if sz := podMap.Delete(pod.Name); sz == 0 {
-			task.log.Info("Accounted for all pods")
-			errs <- nil
-			return
+	for _, r := range re {
+		if r.MatchString(pod.Name) {
+			task.log.V(4).Info("Matched pod", "name", pod.Name)
+			if _, ok := podMap.Get(pod.Name); ok {
+				return
+			}
+			status := string(pod.Status.Phase)
+			task.log.V(4).Info("Informer event", "pod", pod.Name, "status", status)
+			if status != task.Status {
+				return
+			}
+			if err := task.verifyLabels(ctx, pod); err != nil {
+				errs <- err
+				return
+			}
+			if sz := podMap.Set(pod.Name, true); sz == count {
+				task.log.Info("Accounted for all pods")
+				errs <- nil
+				return
+			}
 		}
 	}
 }

--- a/pkg/engine/check_pod_task_test.go
+++ b/pkg/engine/check_pod_task_test.go
@@ -105,7 +105,7 @@ func TestCheckPodParams(t *testing.T) {
 			eng, err := New(testLogger, nil, tc.simClients)
 			require.NoError(t, err)
 			if len(tc.refTaskId) != 0 {
-				eng.objMap[tc.refTaskId] = nil
+				eng.objInfoMap[tc.refTaskId] = nil
 			}
 			task, err := eng.GetTask(&config.Task{
 				ID:     taskID,
@@ -116,7 +116,7 @@ func TestCheckPodParams(t *testing.T) {
 				require.EqualError(t, err, tc.err)
 				require.Nil(t, tc.task)
 			} else {
-				tc.task.getter = eng
+				tc.task.accessor = eng
 				require.NoError(t, err)
 				require.NotNil(t, tc.task)
 				require.Equal(t, tc.task, task)

--- a/pkg/engine/delete_object_task.go
+++ b/pkg/engine/delete_object_task.go
@@ -33,7 +33,7 @@ type DeleteObjTask struct {
 	deleteObjTaskParams
 
 	client *dynamic.DynamicClient
-	getter ObjGetter
+	getter ObjInfoAccessor
 }
 
 type deleteObjTaskParams struct {
@@ -41,7 +41,7 @@ type deleteObjTaskParams struct {
 }
 
 // newDeleteObjTask initializes and returns DeleteObjTask
-func newDeleteObjTask(log logr.Logger, client *dynamic.DynamicClient, getter ObjGetter, cfg *config.Task) (*DeleteObjTask, error) {
+func newDeleteObjTask(log logr.Logger, client *dynamic.DynamicClient, getter ObjInfoAccessor, cfg *config.Task) (*DeleteObjTask, error) {
 	if client == nil {
 		return nil, fmt.Errorf("%s/%s: DynamicClient is not set", cfg.Type, cfg.ID)
 	}

--- a/pkg/engine/delete_object_task_test.go
+++ b/pkg/engine/delete_object_task_test.go
@@ -79,7 +79,7 @@ func TestNewDeleteObjTask(t *testing.T) {
 			eng, err := New(testLogger, nil, tc.simClients)
 			require.NoError(t, err)
 			if len(tc.refTaskId) != 0 {
-				eng.objMap[tc.refTaskId] = nil
+				eng.objInfoMap[tc.refTaskId] = nil
 			}
 
 			task, err := eng.GetTask(&config.Task{

--- a/pkg/engine/engine_test.go
+++ b/pkg/engine/engine_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/klog/v2/textlogger"
@@ -30,11 +31,12 @@ import (
 )
 
 var (
-	errExec           = fmt.Errorf("exec error")
-	errReset          = fmt.Errorf("reset error")
-	testLogger        = textlogger.NewLogger(textlogger.NewConfig())
-	testK8sClient     = &kubernetes.Clientset{}
-	testDynamicClient = &dynamic.DynamicClient{}
+	errExec             = fmt.Errorf("exec error")
+	errReset            = fmt.Errorf("reset error")
+	testLogger          = textlogger.NewLogger(textlogger.NewConfig())
+	testK8sClient       = &kubernetes.Clientset{}
+	testDynamicClient   = &dynamic.DynamicClient{}
+	testDiscoveryClient = &discovery.DiscoveryClient{}
 )
 
 type testEngine struct {

--- a/pkg/engine/object_state.go
+++ b/pkg/engine/object_state.go
@@ -28,8 +28,8 @@ type ObjStateTask struct {
 	BaseTask
 	StateParams
 
-	client *dynamic.DynamicClient
-	getter ObjGetter
+	client   *dynamic.DynamicClient
+	accessor ObjInfoAccessor
 }
 
 // validate initializes and validates parameters for ObjStateTask

--- a/pkg/engine/register_object_task.go
+++ b/pkg/engine/register_object_task.go
@@ -1,0 +1,156 @@
+/*
+ * Copyright (c) 2024, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package engine
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"text/template"
+
+	"github.com/go-logr/logr"
+	"gopkg.in/yaml.v3"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/discovery"
+
+	"github.com/NVIDIA/knavigator/pkg/config"
+)
+
+type RegisterObjTask struct {
+	BaseTask
+	RegisterObjParams
+
+	client   *discovery.DiscoveryClient
+	accessor ObjInfoAccessor
+
+	gvk schema.GroupVersionKind
+}
+
+// newRegisterObjTask initializes and returns RegisterObjTask
+func newRegisterObjTask(log logr.Logger, client *discovery.DiscoveryClient, accessor ObjInfoAccessor, cfg *config.Task) (*RegisterObjTask, error) {
+	if client == nil {
+		return nil, fmt.Errorf("%s/%s: DiscoveryClient is not set", cfg.Type, cfg.ID)
+	}
+
+	task := &RegisterObjTask{
+		BaseTask: BaseTask{
+			log:      log,
+			taskType: cfg.Type,
+			taskID:   cfg.ID,
+		},
+		client:   client,
+		accessor: accessor,
+	}
+
+	if err := task.validate(cfg.Params); err != nil {
+		return nil, err
+	}
+
+	return task, nil
+}
+
+// validate initializes and validates parameters for RegisterObjTask.
+func (task *RegisterObjTask) validate(params map[string]interface{}) error {
+	data, err := yaml.Marshal(params)
+	if err != nil {
+		return fmt.Errorf("%s: failed to parse parameters: %v", task.ID(), err)
+	}
+	if err = yaml.Unmarshal(data, &task.RegisterObjParams); err != nil {
+		return fmt.Errorf("%s: failed to parse parameters: %v", task.ID(), err)
+	}
+
+	if len(task.Template) == 0 {
+		return fmt.Errorf("%s: must specify template", task.ID())
+	}
+
+	tplData, err := os.ReadFile(task.Template)
+	if err != nil {
+		return fmt.Errorf("%s: failed to read %s: %v", task.ID(), task.Template, err)
+	}
+
+	var typeMeta TypeMeta
+	err = yaml.Unmarshal(tplData, &typeMeta)
+	if err != nil {
+		return fmt.Errorf("%s: failed to parse template %s: %v", task.ID(), task.Template, err)
+	}
+
+	task.gvk = schema.FromAPIVersionAndKind(typeMeta.APIVersion, typeMeta.Kind)
+
+	task.objTpl, err = template.ParseFiles(task.Template)
+	if err != nil {
+		return fmt.Errorf("%s: failed to parse template %s: %v", task.ID(), task.Template, err)
+	}
+
+	if len(task.NameFormat) == 0 {
+		return fmt.Errorf("%s: must specify nameFormat", task.ID())
+	}
+
+	if len(task.PodNameFormat) != 0 {
+		if task.podNameTpl, err = template.New("podname").Parse(task.PodNameFormat); err != nil {
+			return fmt.Errorf("%s: failed to parse podname template: %v", task.ID(), err)
+		}
+	}
+
+	if len(task.PodCount) != 0 {
+		if task.podNameTpl == nil {
+			return fmt.Errorf("%s: must define podNameFormat with podCount", task.ID())
+		}
+		if task.podCountTpl, err = template.New("podcount").Parse(task.PodCount); err != nil {
+			return fmt.Errorf("%s: failed to parse podcount template: %v", task.ID(), err)
+		}
+	} else if task.podNameTpl != nil {
+		return fmt.Errorf("%s: must define podCount with podNameFormat", task.ID())
+	}
+
+	return nil
+}
+
+// Exec implements Runnable interface
+func (task *RegisterObjTask) Exec(ctx context.Context) error {
+	switch task.gvk.String() {
+	case "batch/v1, Kind=Job":
+		task.gvr = schema.GroupVersionResource{
+			Group:    task.gvk.Group,
+			Version:  task.gvk.Version,
+			Resource: "jobs",
+		}
+	default:
+		if err := task.getGVR(); err != nil {
+			return err
+		}
+	}
+
+	return task.accessor.SetObjType(task.taskID, &task.RegisterObjParams)
+}
+
+func (task *RegisterObjTask) getGVR() error {
+	apiResourceList, err := task.client.ServerPreferredResources()
+	if err != nil {
+		return fmt.Errorf("%s: failed to retrieve API resources: %v", task.ID(), err)
+	}
+
+	for _, list := range apiResourceList {
+		for _, r := range list.APIResources {
+			if r.Group == task.gvk.Group && r.Kind == task.gvk.Kind {
+				task.gvr = schema.GroupVersionResource{Group: r.Group, Version: r.Version, Resource: r.Name}
+				return nil
+			}
+		}
+	}
+
+	return fmt.Errorf("%s: failed to find resource for %s", task.ID(), task.gvk.String())
+}

--- a/pkg/engine/register_object_task_test.go
+++ b/pkg/engine/register_object_task_test.go
@@ -1,0 +1,162 @@
+/*
+ * Copyright (c) 2024, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package engine
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/NVIDIA/knavigator/pkg/config"
+)
+
+func TestNewRegisterObjTask(t *testing.T) {
+	taskID := "register"
+	testCases := []struct {
+		name       string
+		params     map[string]interface{}
+		simClients bool
+		err        string
+		task       *RegisterObjTask
+		pods       []string
+	}{
+		{
+			name:       "Case 1: no client",
+			params:     nil,
+			simClients: false,
+			err:        "RegisterObj/register: DiscoveryClient is not set",
+		},
+		{
+			name:       "Case 2: missing template",
+			params:     map[string]interface{}{},
+			simClients: true,
+			err:        "RegisterObj/register: must specify template",
+		},
+		{
+			name: "Case 3: bad template path",
+			params: map[string]interface{}{
+				"template": "/does/not/exist",
+			},
+			simClients: true,
+			err:        "RegisterObj/register: failed to read /does/not/exist: open /does/not/exist: no such file or directory",
+		},
+		{
+			name: "Case 4: missing nameFormat",
+			params: map[string]interface{}{
+				"template": "../../resources/templates/example.yml",
+			},
+			simClients: true,
+			err:        "RegisterObj/register: must specify nameFormat",
+		},
+		{
+			name: "Case 5: bad podNameFormat",
+			params: map[string]interface{}{
+				"template":      "../../resources/templates/example.yml",
+				"nameFormat":    "test",
+				"podNameFormat": "test{{",
+			},
+			simClients: true,
+			err:        "RegisterObj/register: failed to parse podname template: template: podname:1: unclosed action",
+		},
+		{
+			name: "Case 6: bad podCount",
+			params: map[string]interface{}{
+				"template":      "../../resources/templates/example.yml",
+				"nameFormat":    "test",
+				"podNameFormat": "test{{._NAME_}}",
+				"podCount":      "test{{",
+			},
+			simClients: true,
+			err:        "RegisterObj/register: failed to parse podcount template: template: podcount:1: unclosed action",
+		},
+		{
+			name: "Case 7: missing podCount",
+			params: map[string]interface{}{
+				"template":      "../../resources/templates/example.yml",
+				"nameFormat":    "test",
+				"podNameFormat": "test{{._NAME_}}",
+			},
+			simClients: true,
+			err:        "RegisterObj/register: must define podCount with podNameFormat",
+		},
+		{
+			name: "Case 8: missing podNameFormat",
+			params: map[string]interface{}{
+				"template":   "../../resources/templates/example.yml",
+				"nameFormat": "test",
+				"podCount":   "2",
+			},
+			simClients: true,
+			err:        "RegisterObj/register: must define podNameFormat with podCount",
+		},
+		{
+			name: "Case 9: valid input",
+			params: map[string]interface{}{
+				"template":      "../../resources/templates/example.yml",
+				"nameFormat":    "test",
+				"podNameFormat": "test{{._NAME_}}",
+				"podCount":      "2",
+			},
+			simClients: true,
+			task: &RegisterObjTask{
+				BaseTask: BaseTask{
+					log:      testLogger,
+					taskType: TaskRegisterObj,
+					taskID:   taskID,
+				},
+				RegisterObjParams: RegisterObjParams{
+					Template:      "../../resources/templates/example.yml",
+					NameFormat:    "test",
+					PodNameFormat: "test{{._NAME_}}",
+					PodCount:      "2",
+				},
+				client: testDiscoveryClient,
+				gvk: schema.GroupVersionKind{
+					Group:   "example.com",
+					Version: "v1",
+					Kind:    "MyObject",
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			eng, err := New(testLogger, nil, tc.simClients)
+			require.NoError(t, err)
+
+			runnable, err := eng.GetTask(&config.Task{
+				ID:     taskID,
+				Type:   TaskRegisterObj,
+				Params: tc.params,
+			})
+			if len(tc.err) != 0 {
+				require.EqualError(t, err, tc.err)
+				require.Nil(t, tc.task)
+			} else {
+				tc.task.accessor = eng
+				require.NoError(t, err)
+				require.NotNil(t, tc.task)
+
+				task := runnable.(*RegisterObjTask)
+				task.objTpl, task.podNameTpl, task.podCountTpl = nil, nil, nil
+				require.Equal(t, tc.task, task)
+			}
+		})
+	}
+}

--- a/pkg/engine/update_object_task.go
+++ b/pkg/engine/update_object_task.go
@@ -35,7 +35,7 @@ type UpdateObjTask struct {
 	ObjStateTask
 }
 
-func newUpdateObjTask(log logr.Logger, client *dynamic.DynamicClient, getter ObjGetter, cfg *config.Task) (*UpdateObjTask, error) {
+func newUpdateObjTask(log logr.Logger, client *dynamic.DynamicClient, accessor ObjInfoAccessor, cfg *config.Task) (*UpdateObjTask, error) {
 	if client == nil {
 		return nil, fmt.Errorf("%s/%s: DynamicClient is not set", cfg.Type, cfg.ID)
 	}
@@ -47,8 +47,8 @@ func newUpdateObjTask(log logr.Logger, client *dynamic.DynamicClient, getter Obj
 				taskType: cfg.Type,
 				taskID:   cfg.ID,
 			},
-			client: client,
-			getter: getter,
+			client:   client,
+			accessor: accessor,
 		},
 	}
 
@@ -61,7 +61,7 @@ func newUpdateObjTask(log logr.Logger, client *dynamic.DynamicClient, getter Obj
 
 // Exec implements Runnable interface
 func (task *UpdateObjTask) Exec(ctx context.Context) error {
-	info, err := task.getter.GetObjInfo(task.RefTaskID)
+	info, err := task.accessor.GetObjInfo(task.RefTaskID)
 	if err != nil {
 		return err
 	}

--- a/pkg/engine/update_object_task_test.go
+++ b/pkg/engine/update_object_task_test.go
@@ -90,7 +90,7 @@ func TestNewUpdateObjTask(t *testing.T) {
 			eng, err := New(testLogger, nil, tc.simClients)
 			require.NoError(t, err)
 			if len(tc.refTaskId) != 0 {
-				eng.objMap[tc.refTaskId] = nil
+				eng.objInfoMap[tc.refTaskId] = nil
 			}
 
 			task, err := eng.GetTask(&config.Task{
@@ -102,7 +102,7 @@ func TestNewUpdateObjTask(t *testing.T) {
 				require.EqualError(t, err, tc.err)
 				require.Nil(t, tc.task)
 			} else {
-				tc.task.getter = eng
+				tc.task.accessor = eng
 				require.NoError(t, err)
 				require.NotNil(t, tc.task)
 				require.Equal(t, tc.task, task)

--- a/pkg/utils/sync_map.go
+++ b/pkg/utils/sync_map.go
@@ -35,10 +35,11 @@ func NewSyncMap() *SyncMap {
 }
 
 // Set sets a key:value pair
-func (m *SyncMap) Set(key interface{}, val interface{}) {
+func (m *SyncMap) Set(key interface{}, val interface{}) int {
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
 	m.data[key] = val
+	return len(m.data)
 }
 
 // Get return a value for a key (first returned argument) if found (second returned argument)

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"flag"
 	"fmt"
+	"regexp"
 	"sync/atomic"
 	"text/template"
 
@@ -78,4 +79,15 @@ func GenerateNames(pattern string, n int, params map[string]interface{}) ([]stri
 		}
 	}
 	return names, nil
+}
+
+func Exp2Regexp(expr []string) ([]*regexp.Regexp, error) {
+	re := make([]*regexp.Regexp, len(expr))
+	for i, r := range expr {
+		var err error
+		if re[i], err = regexp.Compile(r); err != nil {
+			return nil, fmt.Errorf("failed to compile regexp '%s': %v", r, err)
+		}
+	}
+	return re, nil
 }

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -18,6 +18,7 @@ package utils
 
 import (
 	"flag"
+	"regexp"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -102,6 +103,41 @@ func TestGenerateNames(t *testing.T) {
 			} else {
 				require.NoError(t, err)
 				require.Equal(t, tc.names, names)
+			}
+		})
+	}
+}
+
+func TestExp2Regexp(t *testing.T) {
+	testCases := []struct {
+		name string
+		in   []string
+		out  []*regexp.Regexp
+		err  string
+	}{
+		{
+			name: "Case 1: invalid input",
+			in:   []string{"^name[0-9]+$", "(foo(bar)"},
+			err:  "failed to compile regexp '(foo(bar)': error parsing regexp: missing closing ): `(foo(bar)`",
+		},
+		{
+			name: "Case 2: valid input",
+			in:   []string{"^name[0-9]+$", "text"},
+			out: []*regexp.Regexp{
+				regexp.MustCompile("^name[0-9]+$"),
+				regexp.MustCompile("text"),
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			re, err := Exp2Regexp(tc.in)
+			if len(tc.err) != 0 {
+				require.EqualError(t, err, tc.err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tc.out, re)
 			}
 		})
 	}

--- a/resources/tests/k8s/test-failed-job.yml
+++ b/resources/tests/k8s/test-failed-job.yml
@@ -1,17 +1,19 @@
 name: test-k8s-job
 description: submit and validate a k8s job
 tasks:
+- id: register
+  type: RegisterObj
+  params:
+    template: "resources/templates/k8s/failed-job.yml"
+    nameFormat: "job{{._ENUM_}}"
+    podNameFormat: "{{._NAME_}}-[0-9]-.*"
+    podCount: "{{.parallelism}}"
 - id: job
   type: SubmitObj
   params:
+    refTaskId: register
     count: 1
-    grv:
-      group: batch
-      version: v1
-      resource: jobs
-    template: "resources/templates/k8s/failed-job.yml"
-    nameformat: "job{{._ENUM_}}"
-    overrides:
+    params:
       namespace: default
       parallelism: 1
       completions: 1

--- a/resources/tests/k8s/test-job.yml
+++ b/resources/tests/k8s/test-job.yml
@@ -1,17 +1,19 @@
 name: test-k8s-job
 description: submit and validate a k8s job
 tasks:
+- id: register
+  type: RegisterObj
+  params:
+    template: "resources/templates/k8s/job.yml"
+    nameFormat: "job{{._ENUM_}}"
+    podNameFormat: "{{._NAME_}}-[0-9]-.*"
+    podCount: "{{.parallelism}}"
 - id: job
   type: SubmitObj
   params:
+    refTaskId: register
     count: 1
-    grv:
-      group: batch
-      version: v1
-      resource: jobs
-    template: "resources/templates/k8s/job.yml"
-    nameformat: "job{{._ENUM_}}"
-    overrides:
+    params:
       namespace: k8s-test
       parallelism: 2
       completions: 2
@@ -22,3 +24,9 @@ tasks:
       cpu: 100m
       memory: 512M
       gpu: 8
+- id: status
+  type: CheckPod
+  params:
+    refTaskId: job
+    status: Running
+    timeout: 5s

--- a/resources/tests/k8s/test-jobset-with-driver.yml
+++ b/resources/tests/k8s/test-jobset-with-driver.yml
@@ -1,17 +1,19 @@
 name: test-k8s-jobset-with-driver
 description: submit and validate a k8s jobset with 1 driver and 1 worker job
 tasks:
+- id: register
+  type: RegisterObj
+  params:
+    template: "resources/templates/k8s/jobset-with-driver.yml"
+    nameFormat: "jobset{{._ENUM_}}"
+    podNameFormat: "{{._NAME_}}-(worker|driver)-[0-9]+-[0-9]+-.+"
+    podCount: "{{.replicas}}"
 - id: jobset
   type: SubmitObj
   params:
-    count: 1
-    grv:
-      group: jobset.x-k8s.io
-      version: v1alpha2
-      resource: jobsets
-    template: "resources/templates/k8s/jobset-with-driver.yml"
-    nameformat: "jobset{{._ENUM_}}"
-    overrides:
+    refTaskId: register
+    count: 2
+    params:
       namespace: default
       replicas: 1
       parallelism: 1
@@ -23,3 +25,9 @@ tasks:
       cpu: 100m
       memory: 512M
       gpu: 8
+- id: status
+  type: CheckPod
+  params:
+    refTaskId: jobset
+    status: Running
+    timeout: 5s

--- a/resources/tests/k8s/test-jobset.yml
+++ b/resources/tests/k8s/test-jobset.yml
@@ -1,19 +1,21 @@
 name: test-k8s-jobset
 description: submit and validate a k8s jobset with 1 worker job
 tasks:
+- id: register
+  type: RegisterObj
+  params:
+    template: "resources/templates/k8s/jobset.yml"
+    nameFormat: "jobset{{._ENUM_}}"
+    podNameFormat: "{{._NAME_}}-workers-[0-9]+-[0-9]+-.+"
+    podCount: "{{.replicas}}"
 - id: jobset
   type: SubmitObj
   params:
+    refTaskId: register
     count: 1
-    grv:
-      group: jobset.x-k8s.io
-      version: v1alpha2
-      resource: jobsets
-    template: "resources/templates/k8s/jobset.yml"
-    nameformat: "jobset{{._ENUM_}}"
-    overrides:
+    params:
       namespace: default
-      replicas: 1
+      replicas: 2
       parallelism: 1
       completions: 1
       backoffLimit: 0
@@ -23,3 +25,9 @@ tasks:
       cpu: 100m
       memory: 512M
       gpu: 8
+- id: status
+  type: CheckPod
+  params:
+    refTaskId: jobset
+    status: Running
+    timeout: 5s

--- a/resources/tests/kueue/test-job.yml
+++ b/resources/tests/kueue/test-job.yml
@@ -1,17 +1,19 @@
 name: test-kueue-job
 description: submit and validate a kueue job
 tasks:
+- id: register
+  type: RegisterObj
+  params:
+    template: "resources/templates/kueue/job.yml"
+    nameFormat: "job{{._ENUM_}}"
+    podNameFormat: "{{._NAME_}}-[0-9]-.*"
+    podCount: "{{.parallelism}}"
 - id: job
   type: SubmitObj
   params:
+    refTaskId: register
     count: 1
-    grv:
-      group: batch
-      version: v1
-      resource: jobs
-    template: "resources/templates/kueue/job.yml"
-    nameformat: "job{{._ENUM_}}"
-    overrides:
+    params:
       queueName: team-a-queue
       namespace: default
       parallelism: 3
@@ -21,3 +23,9 @@ tasks:
       cpu: 100m
       memory: 512M
       gpu: 1
+- id: status
+  type: CheckPod
+  params:
+    refTaskId: job
+    status: Running
+    timeout: 5s

--- a/resources/tests/volcano/test-job.yml
+++ b/resources/tests/volcano/test-job.yml
@@ -1,17 +1,19 @@
 name: test-volcano-job
 description: submit and manage volcano job
 tasks:
+- id: register
+  type: RegisterObj
+  params:
+    template: "resources/templates/volcano/job.yml"
+    nameFormat: "j{{._ENUM_}}"
+    podNameFormat: "{{._NAME_}}-test-[0-9]+"
+    podCount: "{{.replicas}}"
 - id: job
   type: SubmitObj
   params:
-    count: 1
-    grv:
-      group: batch.volcano.sh
-      version: v1alpha1
-      resource: jobs
-    template: "resources/templates/volcano/job.yml"
-    nameformat: "j{{._ENUM_}}"
-    overrides:
+    refTaskId: register
+    count: 2
+    params:
       namespace: default
       replicas: 2
       priorityClassName: normal-priority
@@ -19,15 +21,9 @@ tasks:
       cpu: 100m
       memory: 512M
       gpu: 8
-    pods:
-      range:
-        pattern: "{{._NAME_}}-test-{{._INDEX_}}"
-        ranges: ["0-1"]
 - id: status
   type: CheckPod
   params:
     refTaskId: job
     status: Running
-    nodeLabels:
-      nodeType: gpu
     timeout: 5s


### PR DESCRIPTION
In the existing setup, each job submission requires us to define the resource's GVR (Group, Version, Resource), template, name format, and the format for pod names. These parameters remain constant.

Currently, if we have multiple "SubmitObj" tasks, we must repeat these parameters for each task.

I suggest we introduce a new task type called "RegisterObj." This task would store all the necessary parameters for a specific CRD in memory. When a job involving that CRD is submitted, the stored parameters would automatically be applied.