### PR TITLE
Add the cleanup support

### DIFF
--- a/cmd/knavigator/main.go
+++ b/cmd/knavigator/main.go
@@ -31,11 +31,16 @@ import (
 )
 
 func mainInternal() error {
-	var kubeConfigPath, kubeCtx, taskConfigs string
-	var qps float64
-	var burst int
+	var (
+		kubeConfigPath, kubeCtx, taskConfigs string
+		qps                                  float64
+		burst                                int
+		cleanupInfo                          engine.CleanupInfo
+	)
 	flag.StringVar(&kubeConfigPath, "kubeconfig", "", "kubeconfig file path")
 	flag.StringVar(&kubeCtx, "kubectx", "", "kube context")
+	flag.BoolVar(&cleanupInfo.Enabled, "cleanup", false, "delete objects")
+	flag.DurationVar(&cleanupInfo.Timeout, "cleanup.timeout", engine.DefaultCleanupTimeout, "time limit for cleanup")
 	flag.StringVar(&taskConfigs, "tasks", "", "comma-separated list of task config files and dirs")
 	flag.Float64Var(&qps, "kube-api-qps", 500, "Maximum QPS to use while talking with Kubernetes API")
 	flag.IntVar(&burst, "kube-api-burst", 500, "Maximum burst for throttle while talking with Kubernetes API")
@@ -68,7 +73,7 @@ func mainInternal() error {
 		return err
 	}
 
-	eng, err := engine.New(log, restConfig)
+	eng, err := engine.New(log, restConfig, &cleanupInfo)
 	if err != nil {
 		return err
 	}

--- a/pkg/engine/check_object_task_test.go
+++ b/pkg/engine/check_object_task_test.go
@@ -87,7 +87,7 @@ func TestNewCheckObjTask(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			eng, err := New(testLogger, nil, tc.simClients)
+			eng, err := New(testLogger, nil, nil, tc.simClients)
 			require.NoError(t, err)
 			if len(tc.refTaskId) != 0 {
 				eng.objInfoMap[tc.refTaskId] = nil

--- a/pkg/engine/check_pod_task_test.go
+++ b/pkg/engine/check_pod_task_test.go
@@ -102,7 +102,7 @@ func TestCheckPodParams(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			eng, err := New(testLogger, nil, tc.simClients)
+			eng, err := New(testLogger, nil, nil, tc.simClients)
 			require.NoError(t, err)
 			if len(tc.refTaskId) != 0 {
 				eng.objInfoMap[tc.refTaskId] = nil

--- a/pkg/engine/delete_object_task_test.go
+++ b/pkg/engine/delete_object_task_test.go
@@ -76,7 +76,7 @@ func TestNewDeleteObjTask(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			eng, err := New(testLogger, nil, tc.simClients)
+			eng, err := New(testLogger, nil, nil, tc.simClients)
 			require.NoError(t, err)
 			if len(tc.refTaskId) != 0 {
 				eng.objInfoMap[tc.refTaskId] = nil

--- a/pkg/engine/engine_test.go
+++ b/pkg/engine/engine_test.go
@@ -40,15 +40,21 @@ var (
 )
 
 type testEngine struct {
-	execErr  error
-	resetErr error
+	execErr   error
+	resetErr  error
+	deleteErr error
 }
 
 func (eng *testEngine) RunTask(context.Context, *config.Task) error {
 	return eng.execErr
 }
+
 func (eng *testEngine) Reset(context.Context) error {
 	return eng.resetErr
+}
+
+func (eng *testEngine) DeleteAllObjects(context.Context) error {
+	return eng.deleteErr
 }
 
 func TestRunEngine(t *testing.T) {

--- a/pkg/engine/pause_task_test.go
+++ b/pkg/engine/pause_task_test.go
@@ -27,7 +27,7 @@ import (
 )
 
 func TestPauseExec(t *testing.T) {
-	eng, err := New(testLogger, nil, false)
+	eng, err := New(testLogger, nil, nil, false)
 	require.NoError(t, err)
 
 	task, err := eng.GetTask(&config.Task{

--- a/pkg/engine/register_object_task_test.go
+++ b/pkg/engine/register_object_task_test.go
@@ -137,7 +137,7 @@ func TestNewRegisterObjTask(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			eng, err := New(testLogger, nil, tc.simClients)
+			eng, err := New(testLogger, nil, nil, tc.simClients)
 			require.NoError(t, err)
 
 			runnable, err := eng.GetTask(&config.Task{

--- a/pkg/engine/sleep_task_test.go
+++ b/pkg/engine/sleep_task_test.go
@@ -66,7 +66,7 @@ func TestSleepParams(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			eng, err := New(testLogger, nil, false)
+			eng, err := New(testLogger, nil, nil, false)
 			require.NoError(t, err)
 
 			task, err := eng.GetTask(&config.Task{

--- a/pkg/engine/submit_object_task_test.go
+++ b/pkg/engine/submit_object_task_test.go
@@ -244,7 +244,7 @@ func TestNewSubmitObjTask(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			utils.SetObjectID(0)
 
-			eng, err := New(testLogger, nil, tc.simClients)
+			eng, err := New(testLogger, nil, nil, tc.simClients)
 			require.NoError(t, err)
 
 			if len(tc.refTaskID) != 0 {

--- a/pkg/engine/types.go
+++ b/pkg/engine/types.go
@@ -27,15 +27,16 @@ import (
 )
 
 const (
-	TaskRegisterObj = "RegisterObj"
-	TaskSubmitObj   = "SubmitObj"
-	TaskUpdateObj   = "UpdateObj"
-	TaskCheckObj    = "CheckObj"
-	TaskDeleteObj   = "DeleteObj"
-	TaskCheckPod    = "CheckPod"
-	TaskUpdateNodes = "UpdateNodes"
-	TaskSleep       = "Sleep"
-	TaskPause       = "Pause"
+	TaskRegisterObj       = "RegisterObj"
+	TaskSubmitObj         = "SubmitObj"
+	TaskUpdateObj         = "UpdateObj"
+	TaskCheckObj          = "CheckObj"
+	TaskDeleteObj         = "DeleteObj"
+	TaskCheckPod          = "CheckPod"
+	TaskUpdateNodes       = "UpdateNodes"
+	TaskSleep             = "Sleep"
+	TaskPause             = "Pause"
+	DefaultCleanupTimeout = 10 * time.Minute
 )
 
 type Runnable interface {

--- a/pkg/engine/update_nodes_task_test.go
+++ b/pkg/engine/update_nodes_task_test.go
@@ -86,7 +86,7 @@ func TestUpdateNodesTask(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			eng, err := New(testLogger, nil, tc.simClients)
+			eng, err := New(testLogger, nil, nil, tc.simClients)
 			require.NoError(t, err)
 			_, err = eng.GetTask(&config.Task{
 				ID:     taskID,

--- a/pkg/engine/update_object_task_test.go
+++ b/pkg/engine/update_object_task_test.go
@@ -87,7 +87,7 @@ func TestNewUpdateObjTask(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			eng, err := New(testLogger, nil, tc.simClients)
+			eng, err := New(testLogger, nil, nil, tc.simClients)
 			require.NoError(t, err)
 			if len(tc.refTaskId) != 0 {
 				eng.objInfoMap[tc.refTaskId] = nil


### PR DESCRIPTION
This PR adds the `cleanup` option to delete all jobs and pods in a test.  
- `--cleanup`
-  `-- cleanup.timeout`  

The initial verification shows it works.  

- Without `--cleanup`, the job remained.
```
./bin/knavigator --tasks resources/tests/k8s/test-job.yml; kubectl get job -n k8s-test
I0515 15:33:07.864033   41806 k8s_config.go:42] "Using external kubeconfig"
I0515 15:33:07.869065   41806 main.go:84] "Starting test" name="test-k8s-job"
I0515 15:33:07.869085   41806 engine.go:103] "Creating task" name="SubmitObj" id="job"
I0515 15:33:07.869617   41806 engine.go:197] "Starting task" id="SubmitObj/job"
I0515 15:33:07.892601   41806 engine.go:203] "Task completed" id="SubmitObj/job" duration="22.973334ms"
I0515 15:33:07.892615   41806 engine.go:209] "Reset Engine"

NAME   STATUS    COMPLETIONS   DURATION   AGE
job1   Running   0/2           0s         0s
```

- With the option `--cleanup`, the job was delete.
```
./bin/knavigator --tasks resources/tests/k8s/test-job.yml --cleanup; kubectl get job -n k8s-test
I0515 15:34:09.350208   41865 k8s_config.go:42] "Using external kubeconfig"
I0515 15:34:09.355431   41865 main.go:84] "Starting test" name="test-k8s-job"
I0515 15:34:09.355452   41865 engine.go:103] "Creating task" name="SubmitObj" id="job"
I0515 15:34:09.356077   41865 engine.go:197] "Starting task" id="SubmitObj/job"
I0515 15:34:09.382863   41865 engine.go:203] "Task completed" id="SubmitObj/job" duration="26.774458ms"
I0515 15:34:09.382878   41865 engine.go:209] "Reset Engine"
I0515 15:34:09.382883   41865 engine.go:215] "Cleaning up objects"
I0515 15:34:09.393272   41865 engine.go:238] "Deleted all objects"

No resources found in k8s-test namespace. 
```

Verified it works for volcano jobs too.
