### PR TITLE
Update golangci config

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -9,8 +9,9 @@ linters:
     - gosimple
     - govet
     - ineffassign
-    - megacheck
     - staticcheck
+    - unused
+    - gosimple
     - typecheck
     - unused
 


### PR DESCRIPTION
Fixed the issue by replacing `megacheck` with `gosimple`, `staticcheck` and `unused` in golint configuration file.

```
WARN [lintersdb] The linter named "megacheck" is deprecated. It has been split into: gosimple, staticcheck, unused.
```

