### PR TITLE
Fix the pod-complete delay issue

### DIFF
--- a/charts/overrides/kwok/pod-complete.yml
+++ b/charts/overrides/kwok/pod-complete.yml
@@ -3,16 +3,40 @@ kind: Stage
 metadata:
   name: pod-complete
 spec:
+  resourceRef:
+    apiGroup: v1
+    kind: Pod
+  selector:
+    matchExpressions:
+    - key: '.metadata.deletionTimestamp'
+      operator: 'DoesNotExist'
+    - key: '.status.phase'
+      operator: 'In'
+      values:
+      - 'Running'
+    - key: '.status.conditions.[] | select( .type == "Ready" ) | .status'
+      operator: 'In'
+      values:
+      - 'True'
+  weight: 1
+  delay:
+    durationMilliseconds: 5000
+    durationFrom:
+      expressionFrom: '.metadata.annotations["pod-complete.stage.kwok.x-k8s.io/delay"]'
+    jitterDurationMilliseconds: 5000
+    jitterDurationFrom:
+      expressionFrom: '.metadata.annotations["pod-complete.stage.kwok.x-k8s.io/jitter-delay"]'
   next:
+    delete: false
     statusTemplate: |
-      {{`{{ $now := Now }}
+      {{ $now := Now }}
       {{ $root := . }}
       containerStatuses:
       {{ range $index, $item := .spec.containers }}
       {{ $origin := index $root.status.containerStatuses $index }}
       - image: {{ $item.image | Quote }}
         name: {{ $item.name | Quote }}
-        ready: false
+        ready: true
         restartCount: 0
         started: false
         state:
@@ -22,15 +46,4 @@ spec:
             reason: Completed
             startedAt: {{ $now | Quote }}
       {{ end }}
-      phase: Succeeded`}}
-  resourceRef:
-    apiGroup: v1
-    kind: Pod
-  selector:
-    matchExpressions:
-    - key: .metadata.deletionTimestamp
-      operator: DoesNotExist
-    - key: .status.phase
-      operator: In
-      values:
-      - Running
+      phase: Succeeded

--- a/resources/templates/k8s/job.yml
+++ b/resources/templates/k8s/job.yml
@@ -23,6 +23,9 @@ spec:
   parallelism: {{.parallelism}}
   completionMode: {{.completionMode}}
   template:
+    metadata:
+      annotations:
+        pod-complete.stage.kwok.x-k8s.io/delay: {{.delay}}
     spec:
       schedulerName: default-scheduler
       containers:

--- a/resources/workflows/k8s/test-job.yml
+++ b/resources/workflows/k8s/test-job.yml
@@ -46,6 +46,7 @@ tasks:
       cpu: 100m
       memory: 512M
       gpu: 8
+      delay: "10s"
 - id: status
   type: CheckPod
   params:


### PR DESCRIPTION
The PR makes the following changes to address the issue of delay not working in the `pod-complete` stage.

- A delay value should be specified as string with a time unit such as "10s".
- Update the pod-complete stage file with the delay parameters.
- Add a delay "10s" to the test k8s job.