### PR TITLE
Fix a pod complete delay problem

### DIFF
--- a/resources/templates/k8s/job.yml
+++ b/resources/templates/k8s/job.yml
@@ -27,6 +27,7 @@ spec:
       annotations:
         {{- if .ttl }}
         pod-complete.stage.kwok.x-k8s.io/delay: "{{.ttl}}"
+        pod-complete.stage.kwok.x-k8s.io/jitter-delay: "{{.ttl}}"
         {{- end }}
     spec:
       schedulerName: default-scheduler

--- a/resources/templates/k8s/jobset-with-driver.yml
+++ b/resources/templates/k8s/jobset-with-driver.yml
@@ -51,6 +51,7 @@ spec:
             annotations:
               {{- if .ttl }}
               pod-complete.stage.kwok.x-k8s.io/delay: "{{.ttl}}"
+              pod-complete.stage.kwok.x-k8s.io/jitter-delay: "{{.ttl}}"
               {{- end }}
           spec:
             schedulerName: default-scheduler

--- a/resources/templates/k8s/jobset.yml
+++ b/resources/templates/k8s/jobset.yml
@@ -38,6 +38,7 @@ spec:
             annotations:
               {{- if .ttl }}
               pod-complete.stage.kwok.x-k8s.io/delay: "{{.ttl}}"
+              pod-complete.stage.kwok.x-k8s.io/jitter-delay: "{{.ttl}}"
               {{- end }}
           spec:
             schedulerName: default-scheduler

--- a/resources/templates/kueue/job.yml
+++ b/resources/templates/kueue/job.yml
@@ -31,6 +31,7 @@ spec:
       annotations:
         {{- if .ttl }}
         pod-complete.stage.kwok.x-k8s.io/delay: "{{.ttl}}"
+        pod-complete.stage.kwok.x-k8s.io/jitter-delay: "{{.ttl}}"
         {{- end }}
     spec:
       containers:

--- a/resources/templates/volcano/job.yml
+++ b/resources/templates/volcano/job.yml
@@ -39,6 +39,7 @@ spec:
         annotations:
           {{- if .ttl }}
           pod-complete.stage.kwok.x-k8s.io/delay: "{{.ttl}}"
+          pod-complete.stage.kwok.x-k8s.io/jitter-delay: "{{.ttl}}"
           {{- end }}
       spec:
         containers:

--- a/resources/templates/yunikorn/job.yml
+++ b/resources/templates/yunikorn/job.yml
@@ -29,6 +29,7 @@ spec:
       annotations:
         {{- if .ttl }}
         pod-complete.stage.kwok.x-k8s.io/delay: "{{.ttl}}"
+        pod-complete.stage.kwok.x-k8s.io/jitter-delay: "{{.ttl}}"
         {{- end }}
     spec:
       schedulerName: yunikorn


### PR DESCRIPTION
Set  `pod-complete.stage.kwok.x-k8s.io/jitter-delay`  in a job template file with the `ttl `value too.  Otherwise, it won't take effect.