### PR TITLE
Fix KWOK delay parameter in testing

### DIFF
--- a/resources/workflows/k8s/test-failed-job.yml
+++ b/resources/workflows/k8s/test-failed-job.yml
@@ -52,8 +52,8 @@ tasks:
       failureReason: nccl-test-failed
       failureMessage: "nccl test failed"
       failureExitCode: 1
-      failureDelay: 1000
-      failureJitterDelay: 5000
+      failureDelay: "5s" 
+      failureJitterDelay: "5s"
 - id: status
   type: CheckPod
   params:


### PR DESCRIPTION
This PR fixes the KWOK delay parameter units by changing the value from `5000` to `5s`. 